### PR TITLE
Returning "User already connected." as success as opposed to error

### DIFF
--- a/src/com/google/plus/samples/quickstart/Signin.java
+++ b/src/com/google/plus/samples/quickstart/Signin.java
@@ -120,7 +120,7 @@ public class Signin {
         // Only connect a user that is not already connected.
         String tokenData = request.session().attribute("token");
         if (tokenData != null) {
-          response.status(400);
+          response.status(200);
           return GSON.toJson("Current user is already connected.");
         }
         // Ensure that this is no request forgery going on, and that the user


### PR DESCRIPTION
The quickstarts will no longer be returning an error if the user is trying to connect but has already connected with the back-end. This update changes the response to be a 200 code, success.
