### PR TITLE
Set default log4j level to remove warning messages

### DIFF
--- a/src/com/google/plus/samples/quickstart/Signin.java
+++ b/src/com/google/plus/samples/quickstart/Signin.java
@@ -35,6 +35,8 @@ import org.mortbay.jetty.Server;
 import org.mortbay.jetty.servlet.ServletHandler;
 import org.mortbay.jetty.servlet.SessionHandler;
 
+import org.apache.log4j.BasicConfigurator;
+
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -111,6 +113,7 @@ public class Signin {
    * @throws Exception from Jetty if the component fails to start
    */
   public static void main(String[] args) throws Exception {
+    BasicConfigurator.configure();
     Server server = new Server(4567);
     ServletHandler servletHandler = new ServletHandler();
     SessionHandler sessionHandler = new SessionHandler();


### PR DESCRIPTION
Log4j is not initialised, and running the application will
result in these warning messages

log4j:WARN No appenders could be found for logger (org.mortbay.log).
log4j:WARN Please initialize the log4j system properly.

This commit sets up default log4j settings. Refer to
https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/BasicConfigurator.html